### PR TITLE
replace boxstream with secretstream

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -1,6 +1,12 @@
 // @ts-ignore
 const pull = require('pull-stream') // @ts-ignore
-const boxes = require('pull-box-stream') // @ts-ignore
+const {
+  KEYBYTES: SECRETSTREAM_KEYBYTES,
+  createEncryptStream,
+  createDecryptStream,
+  // @ts-ignore
+} = require('pull-secretstream')
+// @ts-ignore
 const Handshake = require('pull-handshake')
 const b4a = require('b4a')
 const bs58 = require('bs58')
@@ -214,9 +220,6 @@ function protocol(crypto) {
       function (err, stream, state) {
         if (err) return cb(err)
 
-        const encryptNonce = state.remote.app_mac.slice(0, 24)
-        const decryptNonce = state.local.app_mac.slice(0, 24)
-
         cb(null, {
           remote: state.remote.publicKey,
           // on the server, attach any metadata gathered
@@ -225,17 +228,9 @@ function protocol(crypto) {
           crypto: {
             encryptKey: state.encryptKey,
             decryptKey: state.decryptKey,
-            encryptNonce,
-            decryptNonce,
           },
-          source: pull(
-            stream.source,
-            boxes.createUnboxStream(state.decryptKey, decryptNonce)
-          ),
-          sink: pull(
-            boxes.createBoxStream(state.encryptKey, encryptNonce),
-            stream.sink
-          ),
+          source: pull(stream.source, createDecryptStream(state.decryptKey)),
+          sink: pull(createEncryptStream(state.encryptKey), stream.sink),
         })
       }
     )

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "b4a": "~1.6.4",
     "bs58": "~5.0.0",
     "debug": "^4.3.4",
-    "pull-box-stream": "~1.0.13",
     "pull-handshake": "~1.1.4",
+    "pull-secretstream": "^1.0.0",
     "pull-stream": "~3.7.0",
     "sodium-universal": "~4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bs58": "~5.0.0",
     "debug": "^4.3.4",
     "pull-handshake": "~1.1.4",
-    "pull-secretstream": "^1.0.0",
+    "pull-secretstream": "^2.0.1",
     "pull-stream": "~3.7.0",
     "sodium-universal": "~4.0.0"
   },


### PR DESCRIPTION
~~so far i see that `sodium-secretstream` is throwing an error `pull failed`, which i believe corresponds to [this line in `sodium-native`](https://github.com/sodium-friends/sodium-native/blob/b4d2fec/binding.c#L1846). but not sure why.~~