### PR TITLE
Use secret-channel instead of libsodium secretstream

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -1,11 +1,10 @@
 // @ts-ignore
 const pull = require('pull-stream') // @ts-ignore
 const {
-  KEYBYTES: SECRETSTREAM_KEYBYTES,
-  createEncryptStream,
-  createDecryptStream,
+  pullEncrypter,
+  pullDecrypter,
   // @ts-ignore
-} = require('pull-secretstream')
+} = require('pull-secret-channel')
 // @ts-ignore
 const Handshake = require('pull-handshake')
 const b4a = require('b4a')
@@ -220,6 +219,9 @@ function protocol(crypto) {
       function (err, stream, state) {
         if (err) return cb(err)
 
+        const encryptNonce = state.remote.app_mac.slice(0, 12)
+        const decryptNonce = state.local.app_mac.slice(0, 12)
+
         cb(null, {
           remote: state.remote.publicKey,
           // on the server, attach any metadata gathered
@@ -228,9 +230,17 @@ function protocol(crypto) {
           crypto: {
             encryptKey: state.encryptKey,
             decryptKey: state.decryptKey,
+            encryptNonce,
+            decryptNonce,
           },
-          source: pull(stream.source, createDecryptStream(state.decryptKey)),
-          sink: pull(createEncryptStream(state.encryptKey), stream.sink),
+          source: pull(
+            stream.source,
+            pullDecrypter(state.decryptKey, decryptNonce)
+          ),
+          sink: pull(
+            pullEncrypter(state.encryptKey, encryptNonce),
+            stream.sink
+          ),
         })
       }
     )

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bs58": "~5.0.0",
     "debug": "^4.3.4",
     "pull-handshake": "~1.1.4",
-    "pull-secretstream": "^2.0.1",
+    "pull-secret-channel": "~1.0.0",
     "pull-stream": "~3.7.0",
     "sodium-universal": "~4.0.0"
   },


### PR DESCRIPTION
Since libsodium's secretstream seems a bit much for what we need, I ended up making my own substitute for [Box Stream](https://ssbc.github.io/scuttlebutt-protocol-guide/#box-stream), which I call ["Secret Channel"](https://github.com/ahdinosaur/secret-channel) (which is setup after the "Secret Handshake").

In truth, is more like Box Stream than I initially expected, so is really an upgraded Box Stream: drops the weird byte slicing, uses the latest cipher (ChaCha20-Poly1305, same as TLS 1.3), uses little-endian for the nonce so can be incremented with libsodium's `increment` function.

Happy for this pull request to stay open and not be merged. A new protocol, what gives!? Also I haven't tested this beyond the `secret-handshake-ext` tests.